### PR TITLE
Fix button bitmask being used as a button count, making gamepad mappings impossible

### DIFF
--- a/NFS2SE.asm
+++ b/NFS2SE.asm
@@ -42015,8 +42015,7 @@ loc_421DE3:
 	mov cl, bl
 	mov edi, 1
 	mov edx, dword dword_4E7388[eax]
-	shl edi, cl
-	or edx, edi
+	inc edx
 	mov dword dword_4E7388[eax], edx
 	test ebp, ebp
 	jz loc_421E2C


### PR DESCRIPTION
Port from:
https://github.com/CookiePLMonster/SilentPatchNFS90s/blob/a25a586f83e5ba3e4c82eb23c6fe2e32e07fc313/source/SilentPatchNFS90s.cpp#L619-L627

See https://github.com/zaps166/NFSIISE/issues/104 for a discussion and explanation of this fix.

**WARNING: Untested!**